### PR TITLE
fix(profit): keep revenue figures apart on phone-width bars

### DIFF
--- a/packages/app/cypress/component/profit-estimator-chart.cy.tsx
+++ b/packages/app/cypress/component/profit-estimator-chart.cy.tsx
@@ -1,0 +1,115 @@
+import ProfitEstimatorChart from '@/components/calculator/ProfitEstimatorChart';
+import type { ProfitEstimatorRow } from '@/components/calculator/profit-estimator';
+import type { HardwareConfig } from '@/components/inference/types';
+
+/**
+ * The seven bars from a July-2026 DeepSeek V4 Pro estimate on a phone: three
+ * NVIDIA stacks within 30% of each other and three AMD stacks within 20%, so
+ * neighbouring revenue figures sit at almost the same height. Revenue is
+ * $/GW-year; every row keeps the same 60% TCO / 20% license-fee split.
+ */
+function estimateRow(hwKey: string, revenueBn: number): ProfitEstimatorRow {
+  const revenue = revenueBn * 1e9;
+  const tco = revenue * 0.06;
+  const labCut = revenue * 0.02;
+  return {
+    hwKey,
+    resultKey: hwKey,
+    precision: 'fp4',
+    gpuHours: 1_000_000,
+    revenuePerGpuHour: revenue / 1_000_000,
+    revenue,
+    tco,
+    grossMargin: revenue - tco,
+    labCut,
+    profit: revenue - tco - labCut,
+  };
+}
+
+const ROWS: ProfitEstimatorRow[] = [
+  estimateRow('b300_vllm', 137.1),
+  estimateRow('b300_sglang', 110.3),
+  estimateRow('b200_vllm', 108.7),
+  estimateRow('mi355x_sglang', 38.5),
+  estimateRow('mi355x_mori-sglang', 33.7),
+  estimateRow('mi355x_atom', 32.7),
+  estimateRow('mi355x_vllm', 21.7),
+];
+
+const ASSUMPTIONS = { utilizationPct: 70, labCutPct: 20, basis: 'gw-year' as const };
+
+function colorForRow(row: ProfitEstimatorRow): string {
+  return row.hwKey.startsWith('mi') ? '#ed1c24' : '#76b900';
+}
+
+function mountChart(widthPx: number) {
+  cy.mount(
+    <div style={{ width: widthPx, padding: 16 }}>
+      <ProfitEstimatorChart
+        rows={ROWS}
+        hardwareConfig={{} as HardwareConfig}
+        colorResolver={colorForRow}
+        assumptions={ASSUMPTIONS}
+      />
+    </div>,
+  );
+  cy.get('[data-testid="profit-estimator-chart"] .revenue-label').should(
+    'have.length',
+    ROWS.length,
+  );
+}
+
+/** Left-to-right boxes of every revenue figure and margin line above the bars. */
+function labelBoxes(): Cypress.Chainable<DOMRect[]> {
+  return cy
+    .get('[data-testid="profit-estimator-chart"] .revenue-label tspan')
+    .then(($tspans) =>
+      [...$tspans]
+        .filter((el) => (el.textContent ?? '') !== '')
+        .map((el) => el.getBoundingClientRect()),
+    );
+}
+
+function overlaps(a: DOMRect, b: DOMRect): boolean {
+  return a.left < b.right && b.left < a.right && a.top < b.bottom && b.top < a.bottom;
+}
+
+describe('ProfitEstimatorChart revenue labels', () => {
+  it('never lets neighbouring revenue figures overlap on a phone', () => {
+    // iPhone 15/16 CSS viewport; the card padding leaves the chart ~361px.
+    cy.viewport(393, 852);
+    mountChart(393);
+    cy.screenshot('profit-estimator-chart-phone', { overwrite: true });
+    labelBoxes().then((boxes) => {
+      for (let i = 0; i < boxes.length; i += 1) {
+        for (let j = i + 1; j < boxes.length; j += 1) {
+          expect(overlaps(boxes[i], boxes[j]), `label ${i} and label ${j} overlap`).to.equal(false);
+        }
+      }
+    });
+    // Every figure keeps its compact unit even once the decimal has to go.
+    cy.get('[data-testid="profit-estimator-chart"] .revenue-amount').each(($el) => {
+      expect($el.text()).to.match(/^\$\d+(?:\.\d)?B$/);
+    });
+  });
+
+  it('keeps full precision on a desktop-width chart', () => {
+    cy.viewport(1280, 900);
+    mountChart(1100);
+    cy.screenshot('profit-estimator-chart-desktop', { overwrite: true });
+    cy.get('[data-testid="profit-estimator-chart"] .revenue-amount')
+      .first()
+      .should('have.text', '$137.1B');
+    cy.get('[data-testid="profit-estimator-chart"] .revenue-amount')
+      .first()
+      .parent()
+      .should('have.attr', 'font-size', '12px');
+    labelBoxes().then((boxes) => {
+      for (let i = 0; i < boxes.length; i += 1) {
+        for (let j = i + 1; j < boxes.length; j += 1) {
+          expect(overlaps(boxes[i], boxes[j]), `label ${i} and label ${j} overlap`).to.equal(false);
+        }
+      }
+    });
+  });
+});

--- a/packages/app/src/components/calculator/ProfitEstimatorChart.test.ts
+++ b/packages/app/src/components/calculator/ProfitEstimatorChart.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
 import type { HardwareConfig } from '@/components/inference/types';
+import { CHART_TYPE } from '@/lib/d3-chart/typography';
 
-import type { ProfitEstimatorRow } from './profit-estimator';
+import { formatProfitUsd, type ProfitEstimatorRow } from './profit-estimator';
 import {
+  barLabelSlotPx,
   buildProfitSegments,
+  revenueLabelStyle,
   contrastingTextColor,
   generateProfitTooltipHTML,
   estimateTextWidth,
@@ -368,6 +371,99 @@ describe('contrastingTextColor', () => {
 
   it('falls back to white when the fill cannot be parsed', () => {
     expect(contrastingTextColor('var(--primary)')).toBe('#ffffff');
+  });
+});
+
+describe('barLabelSlotPx', () => {
+  it('lets a label overhang a wide bar by the gap allowance', () => {
+    // Desktop: 100px bars 43px apart; the allowance is the binding limit.
+    expect(barLabelSlotPx(100, 143)).toBe(112);
+  });
+
+  it('stops short of the neighbouring label when the gap is narrower than the allowance', () => {
+    // Phone: seven bars in a 273px plot, 26px wide and 11px apart. Two labels
+    // each borrowing 6px of an 11px gap would meet; the slot leaves air instead.
+    const slot = barLabelSlotPx(26.2, 37.4);
+    expect(slot).toBeLessThan(26.2 + 12);
+    expect(slot).toBeCloseTo(37.4 - 4);
+    // Neighbouring labels centred on their bars cannot overlap.
+    expect(slot).toBeLessThan(37.4);
+  });
+
+  it('is empty for an unmeasured bar and never wider than its own bar plus the allowance', () => {
+    expect(barLabelSlotPx(0, 40)).toBe(0);
+    expect(barLabelSlotPx(Number.NaN, 40)).toBe(0);
+    expect(barLabelSlotPx(30, Number.NaN)).toBe(26);
+  });
+});
+
+/** Width the chart budgets for a weight-700 revenue figure: the regular estimate plus 10%. */
+const boldWidth = (text: string, fontPx: number) => estimateTextWidth(text, fontPx) * 1.1;
+
+describe('revenueLabelStyle', () => {
+  // The bars from the phone screenshot that overlapped: three tall NVIDIA
+  // stacks within 30% of each other and three AMD stacks within 20%.
+  const phoneRows = [137.1e9, 110.3e9, 108.7e9, 38.5e9, 33.7e9, 32.7e9, 21.7e9].map((revenue) =>
+    row({ revenue }),
+  );
+
+  it('keeps full precision at the axis size when every figure fits its slot', () => {
+    expect(revenueLabelStyle(phoneRows, 'gw-year', barLabelSlotPx(100, 143))).toEqual({
+      digits: 1,
+      fontPx: CHART_TYPE.axisLabel,
+    });
+    expect(revenueLabelStyle(phoneRows, 'gw-year')).toEqual({
+      digits: 1,
+      fontPx: CHART_TYPE.axisLabel,
+    });
+  });
+
+  it('narrows every figure until the widest fits a phone-width slot', () => {
+    const slot = barLabelSlotPx(26.2, 37.4);
+    const style = revenueLabelStyle(phoneRows, 'gw-year', slot);
+    // "$110.3B" and "$108.7B" no longer fit side by side; the whole chart drops
+    // to one narrower style rather than mixing sizes between neighbours.
+    expect(style).not.toEqual({ digits: 1, fontPx: CHART_TYPE.axisLabel });
+    for (const r of phoneRows) {
+      const text = formatProfitUsd(r.revenue, 'gw-year', style.digits);
+      expect(boldWidth(text, style.fontPx)).toBeLessThanOrEqual(slot);
+    }
+  });
+
+  it('shrinks before it rounds, and rounds before it shrinks again', () => {
+    const rows = [row({ revenue: 110.3e9 })];
+    const width = (digits: number, fontPx: number) =>
+      boldWidth(formatProfitUsd(110.3e9, 'gw-year', digits), fontPx);
+    expect(revenueLabelStyle(rows, 'gw-year', width(1, CHART_TYPE.annotation))).toEqual({
+      digits: 1,
+      fontPx: CHART_TYPE.annotation,
+    });
+    expect(revenueLabelStyle(rows, 'gw-year', width(0, CHART_TYPE.axisLabel))).toEqual({
+      digits: 0,
+      fontPx: CHART_TYPE.axisLabel,
+    });
+    expect(revenueLabelStyle(rows, 'gw-year', width(0, CHART_TYPE.annotation))).toEqual({
+      digits: 0,
+      fontPx: CHART_TYPE.annotation,
+    });
+  });
+
+  it('falls back to the smallest style rather than failing when nothing fits', () => {
+    expect(revenueLabelStyle(phoneRows, 'gw-year', 1)).toEqual({
+      digits: 0,
+      fontPx: CHART_TYPE.annotation,
+    });
+    expect(revenueLabelStyle([], 'gw-year', 1)).toEqual({
+      digits: 1,
+      fontPx: CHART_TYPE.axisLabel,
+    });
+  });
+
+  it('only changes size per chip-hour, where the formatter keeps its two decimals', () => {
+    const rows = [row({ revenue: 3.96 })];
+    const style = revenueLabelStyle(rows, 'chip-hour', boldWidth('$3.96', CHART_TYPE.annotation));
+    expect(style.fontPx).toBe(CHART_TYPE.annotation);
+    expect(formatProfitUsd(3.96, 'chip-hour', style.digits)).toBe('$3.96');
   });
 });
 

--- a/packages/app/src/components/calculator/ProfitEstimatorChart.tsx
+++ b/packages/app/src/components/calculator/ProfitEstimatorChart.tsx
@@ -94,8 +94,20 @@ function useViewportHeight(): number | undefined {
 const GLYPH_WIDTH_EM = 0.55;
 /** Horizontal breathing room a label needs inside its bar, in px. */
 const LABEL_SIDE_PAD_PX = 4;
-/** The margin line above a bar may borrow this much of the gap to each neighbour, in px. */
+/** The labels above a bar may borrow this much of the gap to each neighbour, in px. */
 const X_GAP_ALLOWANCE = 12;
+
+/**
+ * Horizontal room the labels above a bar may use, in px. A label may overhang
+ * its bar by up to `X_GAP_ALLOWANCE`, but never so far that two neighbours of
+ * similar height touch: on a phone the gap between bars is narrower than the
+ * allowance, so the band step, less a little air, is the real limit.
+ */
+export function barLabelSlotPx(bandwidthPx: number, stepPx: number): number {
+  if (!Number.isFinite(bandwidthPx) || bandwidthPx <= 0) return 0;
+  const step = Number.isFinite(stepPx) && stepPx > bandwidthPx ? stepPx : bandwidthPx;
+  return Math.max(0, Math.min(bandwidthPx + X_GAP_ALLOWANCE, step - LABEL_SIDE_PAD_PX));
+}
 
 /** Rough rendered width of `text` at `fontPx`, for fit tests before anything is drawn. */
 export function estimateTextWidth(text: string, fontPx: number): number {
@@ -327,6 +339,54 @@ export function contrastingTextColor(fill: string): string {
   const luminance =
     0.2126 * channel(parsed.r) + 0.7152 * channel(parsed.g) + 0.0722 * channel(parsed.b);
   return luminance > 0.45 ? '#111111' : '#ffffff';
+}
+
+/** How the revenue figure above every bar is set: compact-unit decimals and font size. */
+export interface RevenueLabelStyle {
+  digits: number;
+  fontPx: number;
+}
+
+/**
+ * Ways to set the revenue figure, richest first. The figure shrinks one step
+ * before it loses its decimal and loses the decimal before it shrinks again:
+ * "$110B" next to "$109B" still ranks the bars and the tooltip keeps the
+ * exact figure, while a figure wider than its slot runs into its neighbour.
+ */
+const REVENUE_LABEL_FULL: RevenueLabelStyle = { digits: 1, fontPx: CHART_TYPE.axisLabel };
+const REVENUE_LABEL_SMALLEST: RevenueLabelStyle = { digits: 0, fontPx: CHART_TYPE.annotation };
+const REVENUE_LABEL_LADDER: readonly RevenueLabelStyle[] = [
+  REVENUE_LABEL_FULL,
+  { digits: 1, fontPx: CHART_TYPE.annotation },
+  { digits: 0, fontPx: CHART_TYPE.axisLabel },
+  REVENUE_LABEL_SMALLEST,
+];
+/** Bold glyphs run wider than the regular estimate; the revenue figure is weight 700. */
+const BOLD_WIDTH_FACTOR = 1.1;
+
+/**
+ * One style for every revenue figure in the chart: the richest rung of the
+ * ladder at which the widest figure still fits `slotPx`. Chosen per chart, not
+ * per bar, so neighbouring figures share a size. Falls back to the last rung
+ * when nothing fits, which only happens below any sensible bar width.
+ */
+export function revenueLabelStyle(
+  rows: readonly Pick<ProfitEstimatorRow, 'revenue'>[],
+  basis: ProfitBasis,
+  slotPx: number = Number.POSITIVE_INFINITY,
+): RevenueLabelStyle {
+  for (const style of REVENUE_LABEL_LADDER) {
+    const widest = Math.max(
+      0,
+      ...rows.map(
+        (row) =>
+          estimateTextWidth(formatProfitUsd(row.revenue, basis, style.digits), style.fontPx) *
+          BOLD_WIDTH_FACTOR,
+      ),
+    );
+    if (widest <= slotPx) return style;
+  }
+  return REVENUE_LABEL_SMALLEST;
 }
 
 /**
@@ -569,6 +629,8 @@ export default function ProfitEstimatorChart({
         const xScale = ctx.xScale as d3.ScaleBand<string>;
         const yScale = ctx.yScale as d3.ScaleLinear<number, number>;
         const bandwidth = xScale.bandwidth();
+        // Widest a label above a bar may be without meeting its neighbour's.
+        const labelSlot = barLabelSlotPx(bandwidth, xScale.step());
 
         // One diagonal-hatch pattern per losing SKU, in that SKU's colour, so a
         // loss reads as "same chip, below the line" rather than as a new colour.
@@ -697,6 +759,14 @@ export default function ProfitEstimatorChart({
         const revenueBaselineY = (d: ProfitSegment) => stackTopPx(d) - REVENUE_LABEL_GAP;
         // Same size the y domain reserved headroom for (both derive from the band width).
         const iconHeight = barMarkHeight(bandwidth);
+        // One format and size for every revenue figure, chosen so the widest
+        // fits its slot: on a phone two bars of similar height used to print
+        // "$110.3B" and "$108.7B" over each other.
+        const revenueStyle = revenueLabelStyle(
+          labelData.map((d) => d.row),
+          basis,
+          labelSlot,
+        );
         group
           .selectAll<SVGImageElement, ProfitSegment>('image.bar-vendor-mark')
           .data(
@@ -727,16 +797,20 @@ export default function ProfitEstimatorChart({
           .attr('x', (d) => (xScale(d.row.resultKey) ?? 0) + bandwidth / 2)
           .attr('y', revenueBaselineY)
           .attr('text-anchor', 'middle')
-          .attr('font-size', px(CHART_TYPE.axisLabel))
+          .attr('font-size', px(revenueStyle.fontPx))
           .attr('font-weight', '700')
           .style('fill', 'var(--foreground)');
         revenueText
           .selectAll<SVGTSpanElement, ProfitSegment>('tspan')
           .data((d) => [
-            { row: d.row, text: formatProfitUsd(d.row.revenue, basis), sub: false },
             {
               row: d.row,
-              text: operatorMarginLabel(d.row, strings.marginShort, bandwidth + X_GAP_ALLOWANCE),
+              text: formatProfitUsd(d.row.revenue, basis, revenueStyle.digits),
+              sub: false,
+            },
+            {
+              row: d.row,
+              text: operatorMarginLabel(d.row, strings.marginShort, labelSlot),
               sub: true,
             },
           ])


### PR DESCRIPTION
## Problem

On a phone (393px viewport) the Revenue-per-GW chart draws the bold revenue figure above each bar at a fixed 12px with no fit check. Bars are ~26px wide there and a figure like `$110.3B` is ~46px, so two neighbours of similar height print over each other (`$110.3B`/`$108.7B`, `$33.7B`/`$32.7B`). The margin line already fit-checked against `bandwidth + 12px`, but that allowance is wider than the actual ~11px gap between phone bars, so even fit-checked labels could touch.

## Fix

- `barLabelSlotPx(bandwidth, step)` — the room a label above a bar may use: still `bandwidth + X_GAP_ALLOWANCE` on wide charts, but capped at the band step less a little air, so neighbouring labels can never meet. The margin line uses the same slot.
- `revenueLabelStyle(rows, basis, slot)` — one style for every revenue figure in the chart, richest first: `$110.3B` @12px → @11px → `$110B` @12px → @11px. Chosen per chart, not per bar, so neighbours never mix sizes; the tooltip keeps the exact figure. Desktop output is unchanged.

## Tests

- Unit tests for both helpers, including the seven bars from the phone screenshot.
- New Cypress component test `profit-estimator-chart.cy.tsx` mounts the real chart at 393×852 and asserts no two revenue/margin label boxes overlap via `getBoundingClientRect`. On `master` it fails with `label 2 and label 4 overlap`; with this change it passes. A desktop-width case pins full precision at 12px.

Before/after screenshots at 393px are in the Slack thread (#gta6-research-inference).

Local: `typecheck`, `lint`, `fmt`, `check:typography`, calculator vitest suite (461 tests) and the new component spec all pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Chart label layout and formatting only; no changes to pricing logic, APIs, or persisted data.
> 
> **Overview**
> Fixes **overlapping bold revenue labels** on narrow Profit Estimator charts (e.g. `$110.3B` / `$108.7B` on ~26px phone bars) by budgeting horizontal space from the band **step**, not just bar width plus a fixed gap.
> 
> Adds **`barLabelSlotPx`** to cap how wide above-bar text (revenue and margin) may extend, and **`revenueLabelStyle`** to pick **one** chart-wide font size and decimal precision from a ladder (shrink before rounding, then round) so every bar uses the same format while the widest label still fits. Desktop behavior stays at full precision when slots are wide enough.
> 
> Coverage: **Vitest** for the new helpers (including the seven-bar phone scenario) and a **Cypress component** spec that asserts revenue/margin label bounding boxes never overlap at 393px and still show `$137.1B` at desktop width.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7df61e9993d61ef7b9864a072353cf11d578eb9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->