### PR TITLE
fix(profit): fit the loss figure under phone-width bars

### DIFF
--- a/packages/app/cypress/component/profit-estimator-chart.cy.tsx
+++ b/packages/app/cypress/component/profit-estimator-chart.cy.tsx
@@ -8,10 +8,11 @@ import type { HardwareConfig } from '@/components/inference/types';
  * neighbouring revenue figures sit at almost the same height. Revenue is
  * $/GW-year; every row keeps the same 60% TCO / 20% license-fee split.
  */
-function estimateRow(hwKey: string, revenueBn: number): ProfitEstimatorRow {
+function estimateRow(hwKey: string, revenueBn: number, profitBn?: number): ProfitEstimatorRow {
   const revenue = revenueBn * 1e9;
-  const tco = revenue * 0.06;
-  const labCut = revenue * 0.02;
+  // A losing row keeps the TCO stack tall enough to leave `profitBn` below zero.
+  const tco = profitBn === undefined ? revenue * 0.06 : revenue - profitBn * 1e9;
+  const labCut = profitBn === undefined ? revenue * 0.02 : 0;
   return {
     hwKey,
     resultKey: hwKey,
@@ -36,17 +37,30 @@ const ROWS: ProfitEstimatorRow[] = [
   estimateRow('mi355x_vllm', 21.7),
 ];
 
+/**
+ * The five bars from a DeepSeek V4.1 Flash estimate on a phone: two SKUs lose
+ * money, one by $561.2M and the last one by $4.9B, and "Loss -$561.2M" used
+ * to run across both neighbouring bands while "Loss -$4.9B" ran off the plot.
+ */
+const LOSING_ROWS: ProfitEstimatorRow[] = [
+  estimateRow('b200_vllm', 14, 5.14),
+  estimateRow('b300_vllm', 11.9, 1.46),
+  estimateRow('gb200_vllm', 9.7, 1.01),
+  estimateRow('gb300_vllm', 9, -0.5612),
+  estimateRow('h200_vllm', 2.9, -4.9),
+];
+
 const ASSUMPTIONS = { utilizationPct: 70, labCutPct: 20, basis: 'gw-year' as const };
 
 function colorForRow(row: ProfitEstimatorRow): string {
   return row.hwKey.startsWith('mi') ? '#ed1c24' : '#76b900';
 }
 
-function mountChart(widthPx: number) {
+function mountChart(widthPx: number, rows: ProfitEstimatorRow[] = ROWS) {
   cy.mount(
     <div style={{ width: widthPx, padding: 16 }}>
       <ProfitEstimatorChart
-        rows={ROWS}
+        rows={rows}
         hardwareConfig={{} as HardwareConfig}
         colorResolver={colorForRow}
         assumptions={ASSUMPTIONS}
@@ -55,8 +69,21 @@ function mountChart(widthPx: number) {
   );
   cy.get('[data-testid="profit-estimator-chart"] .revenue-label').should(
     'have.length',
-    ROWS.length,
+    rows.length,
   );
+}
+
+/** Horizontal extent of every bar column, keyed by the column's centre. */
+function barColumns(): Cypress.Chainable<{ left: number; right: number }[]> {
+  return cy.get('[data-testid="profit-estimator-chart"] rect.bar').then(($rects) => {
+    const byLeft = new Map<number, { left: number; right: number }>();
+    for (const el of $rects) {
+      const r = el.getBoundingClientRect();
+      const key = Math.round(r.left);
+      if (!byLeft.has(key)) byLeft.set(key, { left: r.left, right: r.right });
+    }
+    return [...byLeft.values()].sort((a, b) => a.left - b.left);
+  });
 }
 
 /** Left-to-right boxes of every revenue figure and margin line above the bars. */
@@ -91,6 +118,56 @@ describe('ProfitEstimatorChart revenue labels', () => {
     cy.get('[data-testid="profit-estimator-chart"] .revenue-amount').each(($el) => {
       expect($el.text()).to.match(/^\$\d+(?:\.\d)?B$/);
     });
+  });
+
+  it('keeps every loss figure inside its own band on a phone', () => {
+    cy.viewport(393, 852);
+    mountChart(393, LOSING_ROWS);
+    cy.get('[data-testid="profit-estimator-chart"] .loss-label').should('have.length', 2);
+    cy.screenshot('profit-estimator-chart-phone-loss', { overwrite: true });
+    // The wide figure loses the word and its decimal; the narrow one keeps its decimal.
+    cy.get('[data-testid="profit-estimator-chart"] .loss-label').then(($labels) => {
+      expect([...$labels].map((el) => el.textContent)).to.deep.equal(['-$561M', '-$4.9B']);
+    });
+    cy.get('[data-testid="profit-estimator-chart"] rect.bar')
+      .first()
+      .then(($bar) => {
+        const plot = (
+          $bar[0] as unknown as SVGRectElement
+        ).ownerSVGElement!.getBoundingClientRect();
+        barColumns().then((columns) => {
+          cy.get('[data-testid="profit-estimator-chart"] .loss-label').each(($label) => {
+            const box = $label[0].getBoundingClientRect();
+            const centre = (box.left + box.right) / 2;
+            const own = columns.find((c) => c.left <= centre && centre <= c.right);
+            expect(own, `no bar under "${$label.text()}"`).to.not.equal(undefined);
+            // The figure may overhang its bar into the gap, but never reach the next bar.
+            for (const other of columns) {
+              if (other === own) continue;
+              const intrudes = box.left < other.right && other.left < box.right;
+              expect(intrudes, `"${$label.text()}" reaches into a neighbouring bar`).to.equal(
+                false,
+              );
+            }
+            expect(box.left, `"${$label.text()}" runs off the left of the plot`).to.be.at.least(
+              plot.left,
+            );
+            expect(box.right, `"${$label.text()}" runs off the right of the plot`).to.be.at.most(
+              plot.right,
+            );
+            // Sign and compact unit survive whatever the fit dropped.
+            expect($label.text()).to.match(/^(?:Loss )?-\$\d+(?:\.\d)?[MB]$/);
+          });
+        });
+      });
+  });
+
+  it('keeps the word and the decimal on a desktop-width loss figure', () => {
+    cy.viewport(1280, 900);
+    mountChart(1100, LOSING_ROWS);
+    cy.get('[data-testid="profit-estimator-chart"] .loss-label')
+      .first()
+      .should('have.text', 'Loss -$561.2M');
   });
 
   it('keeps full precision on a desktop-width chart', () => {

--- a/packages/app/cypress/component/profit-estimator-chart.cy.tsx
+++ b/packages/app/cypress/component/profit-estimator-chart.cy.tsx
@@ -132,12 +132,14 @@ describe('ProfitEstimatorChart revenue labels', () => {
     cy.get('[data-testid="profit-estimator-chart"] rect.bar')
       .first()
       .then(($bar) => {
-        const plot = (
-          $bar[0] as unknown as SVGRectElement
-        ).ownerSVGElement!.getBoundingClientRect();
+        const svg = ($bar[0] as unknown as SVGRectElement).ownerSVGElement!;
+        const plot = svg.getBoundingClientRect();
+        const axisTop = svg.querySelector('.x-axis path.domain')!.getBoundingClientRect().top;
         barColumns().then((columns) => {
           cy.get('[data-testid="profit-estimator-chart"] .loss-label').each(($label) => {
             const box = $label[0].getBoundingClientRect();
+            // The deepest loss reaches the domain floor; its figure must still clear the axis line.
+            expect(box.bottom, `"${$label.text()}" sits on the x axis`).to.be.lessThan(axisTop);
             const centre = (box.left + box.right) / 2;
             const own = columns.find((c) => c.left <= centre && centre <= c.right);
             expect(own, `no bar under "${$label.text()}"`).to.not.equal(undefined);

--- a/packages/app/src/components/calculator/ProfitEstimatorChart.test.ts
+++ b/packages/app/src/components/calculator/ProfitEstimatorChart.test.ts
@@ -11,6 +11,8 @@ import {
   contrastingTextColor,
   generateProfitTooltipHTML,
   estimateTextWidth,
+  lossLabelStyle,
+  lossLabelText,
   slantedMargins,
   splitAxisLabel,
   splitHistoryLabel,
@@ -464,6 +466,90 @@ describe('revenueLabelStyle', () => {
     const style = revenueLabelStyle(rows, 'chip-hour', boldWidth('$3.96', CHART_TYPE.annotation));
     expect(style.fontPx).toBe(CHART_TYPE.annotation);
     expect(formatProfitUsd(3.96, 'chip-hour', style.digits)).toBe('$3.96');
+  });
+});
+
+describe('lossLabelStyle', () => {
+  // The DeepSeek V4.1 Flash chart on a phone: two of five bars lose money,
+  // one by $561.2M and the last by $4.9B, and "Loss -$561.2M" ran across
+  // both neighbouring bands.
+  const flashRows = [
+    row({ revenue: 14e9, profit: 5.14e9 }),
+    row({ revenue: 11.9e9, profit: 1.46e9 }),
+    row({ revenue: 9.7e9, profit: 1.01e9 }),
+    row({ revenue: 9e9, profit: -561.2e6 }),
+    row({ revenue: 2.9e9, profit: -4.9e9 }),
+  ];
+  const phoneSlot = barLabelSlotPx(38.2, 54.6);
+
+  it('keeps the word and the decimal when every loss figure fits its slot', () => {
+    expect(lossLabelStyle(flashRows, 'Loss', 'gw-year')).toEqual({ word: true, digits: 1 });
+    expect(lossLabelStyle(flashRows, 'Loss', 'gw-year', barLabelSlotPx(100, 143))).toEqual({
+      word: true,
+      digits: 1,
+    });
+    expect(lossLabelText(-561.2e6, 'Loss', 'gw-year')).toBe('Loss -$561.2M');
+  });
+
+  it('narrows every loss figure until the widest fits a phone-width slot', () => {
+    const style = lossLabelStyle(flashRows, 'Loss', 'gw-year', phoneSlot);
+    expect(style).not.toEqual({ word: true, digits: 1 });
+    for (const losing of flashRows.filter((r) => r.profit < 0)) {
+      const text = lossLabelText(losing.profit, 'Loss', 'gw-year', style, phoneSlot);
+      expect(boldWidth(text, CHART_TYPE.annotation)).toBeLessThanOrEqual(phoneSlot);
+      // The sign and the compact unit survive every rung.
+      expect(text).toMatch(/^(?:Loss )?-\$\d+(?:\.\d)?[MB]$/);
+    }
+  });
+
+  it('lets a bar keep its decimal when only a wider neighbour had to lose it', () => {
+    const style = lossLabelStyle(flashRows, 'Loss', 'gw-year', phoneSlot);
+    expect(style).toEqual({ word: false, digits: 0 });
+    expect(lossLabelText(-561.2e6, 'Loss', 'gw-year', style, phoneSlot)).toBe('-$561M');
+    expect(lossLabelText(-4.9e9, 'Loss', 'gw-year', style, phoneSlot)).toBe('-$4.9B');
+    // Without a slot to test against, the style is applied as given.
+    expect(lossLabelText(-4.9e9, 'Loss', 'gw-year', { word: true, digits: 0 })).toBe('Loss -$5B');
+  });
+
+  it('drops the decimal before the word, and the word before the last decimal', () => {
+    const rows = [row({ profit: -561.2e6 })];
+    const width = (style: { word: boolean; digits: number }) => {
+      const amount = formatProfitUsd(-561.2e6, 'gw-year', style.digits);
+      return boldWidth(style.word ? `Loss ${amount}` : amount, CHART_TYPE.annotation);
+    };
+    expect(lossLabelStyle(rows, 'Loss', 'gw-year', width({ word: true, digits: 0 }))).toEqual({
+      word: true,
+      digits: 0,
+    });
+    expect(lossLabelStyle(rows, 'Loss', 'gw-year', width({ word: false, digits: 1 }))).toEqual({
+      word: false,
+      digits: 1,
+    });
+    expect(lossLabelStyle(rows, 'Loss', 'gw-year', width({ word: false, digits: 0 }))).toEqual({
+      word: false,
+      digits: 0,
+    });
+    expect(lossLabelText(-561.2e6, 'Loss', 'gw-year', { word: false, digits: 0 })).toBe('-$561M');
+  });
+
+  it('ignores profitable rows and falls back to the smallest style when nothing fits', () => {
+    expect(lossLabelStyle([row({ profit: 420 })], 'Loss', 'gw-year', 1)).toEqual({
+      word: true,
+      digits: 1,
+    });
+    expect(lossLabelStyle(flashRows, 'Loss', 'gw-year', 1)).toEqual({ word: false, digits: 0 });
+  });
+
+  it('only drops the word per chip-hour, where the formatter keeps its two decimals', () => {
+    const rows = [row({ profit: -0.57 })];
+    const style = lossLabelStyle(
+      rows,
+      'Loss',
+      'chip-hour',
+      boldWidth('-$0.57', CHART_TYPE.annotation),
+    );
+    expect(style.word).toBe(false);
+    expect(lossLabelText(-0.57, 'Loss', 'chip-hour', style)).toBe('-$0.57');
   });
 });
 

--- a/packages/app/src/components/calculator/ProfitEstimatorChart.test.ts
+++ b/packages/app/src/components/calculator/ProfitEstimatorChart.test.ts
@@ -18,6 +18,7 @@ import {
   splitHistoryLabel,
   xLabelLayout,
   operatorMarginLabel,
+  LOSS_FOOTROOM_PX,
   profitYDomain,
   BAR_ICON_MAX_HEIGHT,
   BAR_ICON_MIN_HEIGHT,
@@ -139,6 +140,24 @@ describe('profitYDomain', () => {
     const [, roomy] = profitYDomain([row()], 500, stackHeadroomPx(BAR_ICON_MAX_HEIGHT));
     expect(roomy).toBeGreaterThan(top);
     expect((roomy - 1000) * (500 / roomy)).toBeCloseTo(stackHeadroomPx(BAR_ICON_MAX_HEIGHT), 5);
+  });
+
+  it('reserves pixel footroom under the deepest loss once the plot height is known', () => {
+    const losing = row({ revenue: 300, tco: 400, grossMargin: -100, labCut: 0, profit: -100 });
+    const [bottom, top] = profitYDomain([losing], 500);
+    const pxPerUnit = 500 / (top - bottom);
+    // The loss figure hangs LOSS_FOOTROOM_PX below the hatch, so the floor sits that far under it.
+    expect((-100 - bottom) * pxPerUnit).toBeCloseTo(LOSS_FOOTROOM_PX, 5);
+    // The headroom above the stack is unchanged by the footroom.
+    expect((top - 400) * pxPerUnit).toBeCloseTo(STACK_HEADROOM_PX, 5);
+    // A loss that fills nearly the whole plot still keeps its figure clear of the axis.
+    const deep = row({ revenue: 100, tco: 2000, grossMargin: -1900, labCut: 0, profit: -1900 });
+    const [deepBottom, deepTop] = profitYDomain([deep], 300);
+    expect((-1900 - deepBottom) * (300 / (deepTop - deepBottom))).toBeCloseTo(LOSS_FOOTROOM_PX, 5);
+  });
+
+  it('reserves no footroom when nothing loses money', () => {
+    expect(profitYDomain([row()], 500)[0]).toBe(0);
   });
 
   it('extends below zero when any SKU loses money, and covers TCO when it exceeds revenue', () => {

--- a/packages/app/src/components/calculator/ProfitEstimatorChart.tsx
+++ b/packages/app/src/components/calculator/ProfitEstimatorChart.tsx
@@ -363,6 +363,10 @@ const REVENUE_LABEL_LADDER: readonly RevenueLabelStyle[] = [
 ];
 /** Bold glyphs run wider than the regular estimate; the revenue figure is weight 700. */
 const BOLD_WIDTH_FACTOR = 1.1;
+/** Rough rendered width of bold `text` at `fontPx`. */
+function boldWidth(text: string, fontPx: number): number {
+  return estimateTextWidth(text, fontPx) * BOLD_WIDTH_FACTOR;
+}
 
 /**
  * One style for every revenue figure in the chart: the richest rung of the
@@ -378,15 +382,96 @@ export function revenueLabelStyle(
   for (const style of REVENUE_LABEL_LADDER) {
     const widest = Math.max(
       0,
-      ...rows.map(
-        (row) =>
-          estimateTextWidth(formatProfitUsd(row.revenue, basis, style.digits), style.fontPx) *
-          BOLD_WIDTH_FACTOR,
+      ...rows.map((row) =>
+        boldWidth(formatProfitUsd(row.revenue, basis, style.digits), style.fontPx),
       ),
     );
     if (widest <= slotPx) return style;
   }
   return REVENUE_LABEL_SMALLEST;
+}
+
+/** How the loss figure under a losing bar is set: whether the word stays, and the compact-unit decimals. */
+export interface LossLabelStyle {
+  word: boolean;
+  digits: number;
+}
+
+/**
+ * Ways to set the loss figure, richest first. The word goes before the figure
+ * loses precision entirely: the hatch below the axis and the red fill already
+ * say "loss", while "Loss -$561.2M" under a phone-width bar ran into both
+ * neighbours and "Loss -$4.9B" under the last bar ran off the plot.
+ */
+const LOSS_LABEL_FULL: LossLabelStyle = { word: true, digits: 1 };
+const LOSS_LABEL_SMALLEST: LossLabelStyle = { word: false, digits: 0 };
+const LOSS_LABEL_LADDER: readonly LossLabelStyle[] = [
+  LOSS_LABEL_FULL,
+  { word: true, digits: 0 },
+  { word: false, digits: 1 },
+  LOSS_LABEL_SMALLEST,
+];
+
+/**
+ * The loss figure for one bar in `style`: "Loss -$561.2M", "Loss -$561M",
+ * "-$561.2M" or "-$561M". When the chart had to drop the decimal for its
+ * widest figure, a bar whose own figure still fits `slotPx` keeps it: loss
+ * figures hang at different depths, so they never compete for one line the
+ * way the revenue figures do, and "-$4.9B" says more than "-$5B". With no
+ * `slotPx` the style is applied as given.
+ */
+export function lossLabelText(
+  profit: number,
+  lossWord: string,
+  basis: ProfitBasis,
+  style: LossLabelStyle = LOSS_LABEL_FULL,
+  slotPx?: number,
+): string {
+  if (style.digits === 0 && slotPx !== undefined) {
+    const precise = lossTextIn(profit, lossWord, basis, { word: style.word, digits: 1 });
+    if (lossTextWidth(precise) <= slotPx) return precise;
+  }
+  return lossTextIn(profit, lossWord, basis, style);
+}
+
+/** The loss figure set exactly in `style`, with no fit test. */
+function lossTextIn(
+  profit: number,
+  lossWord: string,
+  basis: ProfitBasis,
+  style: LossLabelStyle,
+): string {
+  const amount = formatProfitUsd(profit, basis, style.digits);
+  return style.word ? `${lossWord} ${amount}` : amount;
+}
+
+/** Budgeted width of a loss figure: annotation size, weight 600, so measured like the bold revenue figure. */
+function lossTextWidth(text: string): number {
+  return boldWidth(text, CHART_TYPE.annotation);
+}
+
+/**
+ * One style for every loss figure in the chart: the richest rung of the ladder
+ * at which the widest figure still fits `slotPx`. Chosen per chart, as the
+ * revenue style is, so two losing bars read the same way. The figure is set
+ * at the annotation size in weight 600, so it is budgeted like the bold
+ * revenue figure.
+ */
+export function lossLabelStyle(
+  rows: readonly Pick<ProfitEstimatorRow, 'profit'>[],
+  lossWord: string,
+  basis: ProfitBasis,
+  slotPx: number = Number.POSITIVE_INFINITY,
+): LossLabelStyle {
+  const losing = rows.filter((row) => row.profit < 0);
+  for (const style of LOSS_LABEL_LADDER) {
+    const widest = Math.max(
+      0,
+      ...losing.map((row) => lossTextWidth(lossTextIn(row.profit, lossWord, basis, style))),
+    );
+    if (widest <= slotPx) return style;
+  }
+  return LOSS_LABEL_SMALLEST;
 }
 
 /**
@@ -829,6 +914,15 @@ export default function ProfitEstimatorChart({
           )
           .text((d) => d.text);
 
+        // The loss figure is fitted to the same slot as the revenue figure:
+        // unfitted, "Loss -$561.2M" under a phone-width bar overran both
+        // neighbours' bands.
+        const lossStyle = lossLabelStyle(
+          labelData.map((d) => d.row),
+          strings.loss,
+          basis,
+          labelSlot,
+        );
         group
           .selectAll<SVGTextElement, ProfitSegment>('.loss-label')
           .data(
@@ -843,7 +937,7 @@ export default function ProfitEstimatorChart({
           .attr('font-size', px(CHART_TYPE.annotation))
           .attr('font-weight', '600')
           .style('fill', LOSS_FILL)
-          .text((d) => `${strings.loss} ${formatProfitUsd(d.row.profit, basis)}`);
+          .text((d) => lossLabelText(d.row.profit, strings.loss, basis, lossStyle, labelSlot));
 
         return bars;
       },

--- a/packages/app/src/components/calculator/ProfitEstimatorChart.tsx
+++ b/packages/app/src/components/calculator/ProfitEstimatorChart.tsx
@@ -540,10 +540,21 @@ export function stackHeadroomPx(iconHeightPx = BAR_ICON_MIN_HEIGHT): number {
 /** Headroom with the smallest vendor mark; what a phone-width chart reserves. */
 export const STACK_HEADROOM_PX = stackHeadroomPx();
 
+/** Baseline of the loss figure below the bottom of its hatch, in px. */
+const LOSS_LABEL_DY = 14;
+/**
+ * Pixels the deepest loss needs below it: the loss figure's baseline offset
+ * plus a text line of clearance before the axis line. Without this the figure
+ * of a loss that reaches the domain floor sat on top of the x axis.
+ */
+export const LOSS_FOOTROOM_PX = LOSS_LABEL_DY + CHART_TYPE.annotation;
+
 /**
  * Y domain for the bars. The top is the tallest positive stack plus exactly the
- * pixel headroom its labels need (`headroomPx`), converted to data units through
- * `plotHeightPx` (a proportional 30% fallback when the plot has not been measured yet).
+ * pixel headroom its labels need (`headroomPx`); the bottom is the deepest loss
+ * plus the pixel footroom its figure needs (`LOSS_FOOTROOM_PX`, none when nothing
+ * loses money). Both are converted to data units through `plotHeightPx`, with a
+ * proportional fallback (30% above, 12% below) when the plot has not been measured yet.
  */
 export function profitYDomain(
   rows: readonly ProfitEstimatorRow[],
@@ -556,9 +567,13 @@ export function profitYDomain(
   const top = Math.max(0, ...rows.map(stackTopValue));
   const bottom = Math.min(0, ...rows.map((row) => row.profit));
   const span = top - bottom;
-  const headroom =
-    plotHeightPx > headroomPx * 2 ? (span * headroomPx) / (plotHeightPx - headroomPx) : span * 0.3;
-  return [bottom * 1.12, top === 0 ? 1 : top + headroom];
+  const footroomPx = bottom < 0 ? LOSS_FOOTROOM_PX : 0;
+  const reservedPx = headroomPx + footroomPx;
+  if (plotHeightPx > reservedPx * 2) {
+    const unitsPerPx = span / (plotHeightPx - reservedPx);
+    return [bottom - unitsPerPx * footroomPx, top === 0 ? 1 : top + unitsPerPx * headroomPx];
+  }
+  return [bottom * 1.12, top === 0 ? 1 : top + span * 0.3];
 }
 
 export function rowLabel(
@@ -932,7 +947,7 @@ export default function ProfitEstimatorChart({
           .join('text')
           .attr('class', 'loss-label')
           .attr('x', (d) => (xScale(d.row.resultKey) ?? 0) + bandwidth / 2)
-          .attr('y', (d) => yScale(d.row.profit) + 14)
+          .attr('y', (d) => yScale(d.row.profit) + LOSS_LABEL_DY)
           .attr('text-anchor', 'middle')
           .attr('font-size', px(CHART_TYPE.annotation))
           .attr('font-weight', '600')


### PR DESCRIPTION
## Problem

Follow-up to #1132. On a phone-width profit estimator chart the loss figure under a losing bar is set at a fixed format with no fit test, so on DeepSeek V4.1 Flash `Loss -$561.2M` runs across both neighbouring bands and `Loss -$4.9B` under the last bar runs off the right edge of the plot (reported from prod, iPhone 393px).

## Fix

- `lossLabelStyle(rows, lossWord, basis, slotPx)` picks one rung per chart, fitted to the same `barLabelSlotPx` slot the revenue figure uses: `Loss -$561.2M` → `Loss -$561M` → `-$561.2M` → `-$561M`. The word goes before the last decimal: the hatch below the axis and the red fill already say "loss".
- `lossLabelText(..., style, slotPx)` lets an individual bar keep its decimal when its own figure fits. Loss figures hang at different depths so they never compete for one line the way the revenue figures do; the phone renders `-$561M` and `-$4.9B` rather than `-$5B`.
- `boldWidth` is shared with `revenueLabelStyle` (weight-600/700 figures are budgeted at 1.1× the regular estimate).
- Desktop is unchanged: `Loss -$561.2M`.

## Tests

- 6 new unit tests in `ProfitEstimatorChart.test.ts` (ladder order, per-bar decimal, chip-hour basis, fallbacks).
- Two new cases in `cypress/component/profit-estimator-chart.cy.tsx` mount the real chart with the V4.1 Flash-shaped rows (two losing bars) at 393×852 and assert every `.loss-label` box stays within its own bar column and inside the plot SVG, and pin the rendered texts (`-$561M`, `-$4.9B`); a desktop case pins `Loss -$561.2M`. The phone case fails on master with `"Loss -$561.2M" reaches into a neighbouring bar`.


## Follow-up: loss figure vs the x axis

`profitYDomain` padded the floor proportionally (`bottom * 1.12`) while the loss figure hangs a fixed 14px below its hatch, so a loss that reached the domain floor (H200 at -$4.9B on the 5-bar phone chart) drew its figure across the x-axis line. The floor now reserves `LOSS_FOOTROOM_PX` (baseline offset + one annotation line) below the deepest loss, converted to data units the same way the stack headroom is above the tallest bar; no footroom when nothing loses money.

- Unit tests: footroom is exactly `LOSS_FOOTROOM_PX` in pixels once the plot height is known (shallow and near-full-plot losses), headroom unchanged, no footroom without a loss.
- Cypress phone-loss case now also asserts every loss figure ends above `.x-axis path.domain`; fails on the previous commit with `"-$4.9B" sits on the x axis`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Chart label layout and y-domain padding only; no pricing, auth, or API changes.
> 
> **Overview**
> Fixes **phone-width profit estimator charts** where loss amounts under losing bars used a fixed `Loss -$…` string and spilled into neighboring columns or off the plot.
> 
> The chart now **fits loss labels** the same way as revenue: `lossLabelStyle` picks one ladder rung per chart against `barLabelSlotPx`, and `lossLabelText` can keep a bar’s decimal when only a wider neighbor had to shorten. **`profitYDomain`** also reserves **`LOSS_FOOTROOM_PX`** below the deepest loss so labels clear the x-axis. Desktop keeps full text (e.g. `Loss -$561.2M`).
> 
> Coverage adds **unit tests** for the loss ladder and y-domain footroom, plus **Cypress** cases that assert loss label bounds and strings on a ~393px viewport.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aca8441684e3692cb2d9dc8756b7ac7ead1b1d9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->