### PR TITLE
fix(export): hide PNG legend when line labels are enabled / 启用曲线标签时隐藏 PNG 图例

### DIFF
--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -289,6 +289,7 @@ export default function ChartDisplay({ embedded = false }: { embedded?: boolean 
     selectedPercentile,
     selectedXAxisMode,
     tokenRevenuePricing,
+    showLineLabels,
   } = useInferenceDisplay();
   const { setSelectedDates, setSelectedDatesFromRunExpansion, setIsLegendExpanded } =
     useInferenceActions();
@@ -937,6 +938,7 @@ export default function ChartDisplay({ embedded = false }: { embedded?: boolean 
                       }
                       hideImageExport={getViewMode(graphIndex) === 'table'}
                       setIsLegendExpanded={setIsLegendExpanded}
+                      hideLegendOnExport={showLineLabels}
                       exportFileName={`InferenceX_${selectedModel}_${graph.chartDefinition.chartType}`}
                       onExportMp4={
                         replayAvailable

--- a/packages/app/src/components/inference/ui/line-label-layer.test.ts
+++ b/packages/app/src/components/inference/ui/line-label-layer.test.ts
@@ -82,6 +82,25 @@ describe('point-label plot bounding box primitives', () => {
 });
 
 describe('line-label placement', () => {
+  it('reserves enough vertical space for the larger line-label pills', () => {
+    const labels = placeLineLabels(
+      [
+        series('first', [{ x: 50, y: 50 }]),
+        series('second', [
+          { x: 0, y: 60 },
+          { x: 50, y: 70 },
+          { x: 100, y: 100 },
+        ]),
+      ],
+      identity,
+      identity,
+      { collisionWidth: 60 },
+    );
+
+    // A 20px gap cleared the old 18px threshold, but not a 16px label plus padding.
+    expect(labels[1]).toMatchObject({ x: 100, y: 100, visible: true });
+  });
+
   it('uses later candidates when the preferred anchor collides', () => {
     const labels = placeLineLabels(
       [

--- a/packages/app/src/components/inference/ui/line-label-layer.test.ts
+++ b/packages/app/src/components/inference/ui/line-label-layer.test.ts
@@ -97,7 +97,7 @@ describe('line-label placement', () => {
       { collisionWidth: 60 },
     );
 
-    // A 20px gap cleared the old 18px threshold, but not a 16px label plus padding.
+    // A 20px gap cleared the old 18px threshold, but not a 13px label plus padding.
     expect(labels[1]).toMatchObject({ x: 100, y: 100, visible: true });
   });
 

--- a/packages/app/src/components/inference/ui/line-label-layer.ts
+++ b/packages/app/src/components/inference/ui/line-label-layer.ts
@@ -144,7 +144,8 @@ interface PillLayoutItem {
  * mirror image below/above its anchor, the mirror image on the other side of
  * its anchor, and both mirrors together. Every candidate is clamped into
  * `bounds` before the overlap test, so nothing leaves the plot. When every
- * candidate collides the default spot is kept: an overlapped label is still
+ * mirrored candidate collides, nearby rows are tried before the default spot
+ * is kept: an overlapped label is still
  * better than a missing one, and the fallback matches what the anchor pass
  * already tolerates for pinned anchors.
  *
@@ -183,6 +184,14 @@ function layoutPills(
       [mirrorX, ty0],
       [mirrorX, mirrorY],
     ];
+    // Larger labels can fill both mirrored slots in a dense cluster. Try
+    // nearby rows using the measured pill height before accepting overlap.
+    const rowHeight = local.bottom - local.top + 4;
+    for (let row = 1; row <= 3; row++) {
+      for (const cx of [tx0, mirrorX]) {
+        candidates.push([cx, ty0 - row * rowHeight], [cx, ty0 + row * rowHeight]);
+      }
+    }
 
     const clamped = candidates.map(([cx, cy]) => {
       const shift = pillShiftIntoBounds(pillBoxAt(local, cx, cy), bounds);

--- a/packages/app/src/components/inference/ui/line-label-layer.ts
+++ b/packages/app/src/components/inference/ui/line-label-layer.ts
@@ -2,6 +2,7 @@ import * as d3 from 'd3';
 
 import { pointNearestX } from '@/components/inference/ui/line-label-anchor';
 import { plotClipSize } from '@/lib/d3-chart/plot-bounds';
+import { CHART_TYPE, px } from '@/lib/d3-chart/typography';
 
 export interface CartesianPoint {
   x: number;
@@ -321,7 +322,7 @@ export function placeLineLabels<TPoint extends CartesianPoint>(
     obstacles?: readonly PlacedBox[];
   },
 ): LineLabelPlacement[] {
-  const collisionHeight = options.collisionHeight ?? 18;
+  const collisionHeight = options.collisionHeight ?? CHART_TYPE.lineLabel + 8;
   const placed: PlacedBox[] = [...(options.obstacles ?? [])];
   const result: LineLabelPlacement[] = [];
   const sorted = [...series].toSorted(
@@ -460,7 +461,7 @@ export function renderLineLabels(
           .attr('text-anchor', 'start')
           .attr('dominant-baseline', 'central')
           .attr('fill', 'white')
-          .attr('font-size', '10px')
+          .attr('font-size', px(CHART_TYPE.lineLabel))
           .attr('font-weight', '600');
         return labelGroup;
       },

--- a/packages/app/src/components/inference/ui/line-label-pill-bounds.test.ts
+++ b/packages/app/src/components/inference/ui/line-label-pill-bounds.test.ts
@@ -197,13 +197,13 @@ describe('clamped pills do not stack on their neighbours', () => {
     const label = placement('gpu', 395, 4, 'MI355X');
     renderLineLabels(zoomGroup, [label], { seriesAttribute: 'data-hw-key' });
 
-    expect(zoomGroup.select('.ll-text').attr('font-size')).toBe('16px');
-    expect(Number(zoomGroup.select('.ll-bg').attr('height'))).toBe(22);
-    expect(Number(zoomGroup.select('.ll-bg').attr('width'))).toBeCloseTo(67.6);
+    expect(zoomGroup.select('.ll-text').attr('font-size')).toBe('13px');
+    expect(Number(zoomGroup.select('.ll-bg').attr('height'))).toBe(19);
+    expect(Number(zoomGroup.select('.ll-bg').attr('width'))).toBeCloseTo(56.8);
     expectInsidePlot(pillBox(zoomGroup, 'gpu'));
 
     updateRenderedLineLabels(zoomGroup, [{ ...label, x: 398, y: 298 }]);
-    expect(zoomGroup.select('.ll-text').attr('font-size')).toBe('16px');
+    expect(zoomGroup.select('.ll-text').attr('font-size')).toBe('13px');
     expectInsidePlot(pillBox(zoomGroup, 'gpu'));
   });
 

--- a/packages/app/src/components/inference/ui/line-label-pill-bounds.test.ts
+++ b/packages/app/src/components/inference/ui/line-label-pill-bounds.test.ts
@@ -166,6 +166,20 @@ describe('pill bounding box primitives', () => {
 });
 
 describe('clamped pills do not stack on their neighbours', () => {
+  it('uses nearby rows when a dense cluster fills both mirrored positions', () => {
+    const { zoomGroup } = renderChart();
+    renderLineLabels(
+      zoomGroup,
+      ['a', 'b', 'c', 'd', 'e'].map((key) => placement(key, 200, 150, 'MI355X (SGLang)')),
+      { seriesAttribute: 'data-hw-key' },
+    );
+    const boxes = ['a', 'b', 'c', 'd', 'e'].map((key) => pillBox(zoomGroup, key));
+    for (const [index, box] of boxes.entries()) {
+      expectInsidePlot(box);
+      for (const other of boxes.slice(index + 1)) expect(overlaps(box, other)).toBe(false);
+    }
+  });
+
   it('renders larger text and measures its pill before clamping on render and zoom', () => {
     Object.defineProperty(SVGElement.prototype, 'getBBox', {
       configurable: true,

--- a/packages/app/src/components/inference/ui/line-label-pill-bounds.test.ts
+++ b/packages/app/src/components/inference/ui/line-label-pill-bounds.test.ts
@@ -166,6 +166,33 @@ describe('pill bounding box primitives', () => {
 });
 
 describe('clamped pills do not stack on their neighbours', () => {
+  it('renders larger text and measures its pill before clamping on render and zoom', () => {
+    Object.defineProperty(SVGElement.prototype, 'getBBox', {
+      configurable: true,
+      value(this: SVGElement) {
+        const fontSize = Number.parseFloat(this.getAttribute('font-size') ?? '0');
+        return new DOMRect(
+          0,
+          -fontSize / 2,
+          (this.textContent ?? '').length * fontSize * 0.6,
+          fontSize,
+        );
+      },
+    });
+    const { zoomGroup } = renderChart();
+    const label = placement('gpu', 395, 4, 'MI355X');
+    renderLineLabels(zoomGroup, [label], { seriesAttribute: 'data-hw-key' });
+
+    expect(zoomGroup.select('.ll-text').attr('font-size')).toBe('16px');
+    expect(Number(zoomGroup.select('.ll-bg').attr('height'))).toBe(22);
+    expect(Number(zoomGroup.select('.ll-bg').attr('width'))).toBeCloseTo(67.6);
+    expectInsidePlot(pillBox(zoomGroup, 'gpu'));
+
+    updateRenderedLineLabels(zoomGroup, [{ ...label, x: 398, y: 298 }]);
+    expect(zoomGroup.select('.ll-text').attr('font-size')).toBe('16px');
+    expectInsidePlot(pillBox(zoomGroup, 'gpu'));
+  });
+
   it('flips a pill below its anchor when the neighbour above was slid down onto it', () => {
     // Bugbot's case: `placeLineLabels` cleared these two anchors (they are
     // 26px apart, more than one collision height), but the top pill has to

--- a/packages/app/src/components/ui/chart-buttons.tsx
+++ b/packages/app/src/components/ui/chart-buttons.tsx
@@ -19,6 +19,8 @@ interface ChartButtonsProps {
   zoomResetEvent?: string;
   /** Optional setter to temporarily expand legend during export */
   setIsLegendExpanded?: (expanded: boolean) => void;
+  /** Omit the legend from PNG exports when series are labeled in the plot. */
+  hideLegendOnExport?: boolean;
   /** Hide the zoom reset button (e.g., for charts without zoom) */
   hideZoomReset?: boolean;
   /** Hide the PNG image export button (e.g., for table views) */
@@ -57,6 +59,7 @@ export function ChartButtons({
   analyticsPrefix,
   zoomResetEvent,
   setIsLegendExpanded,
+  hideLegendOnExport,
   hideZoomReset,
   hideImageExport,
   onExportCsv,
@@ -88,6 +91,7 @@ export function ChartButtons({
   const { isExporting, exportToImage } = useChartExport({
     chartId,
     setIsLegendExpanded,
+    hideLegend: hideLegendOnExport,
     exportFileName,
   });
   const [popoverOpen, setPopoverOpen] = useState(false);

--- a/packages/app/src/components/ui/d3-chart-wrapper.tsx
+++ b/packages/app/src/components/ui/d3-chart-wrapper.tsx
@@ -152,7 +152,10 @@ export function D3ChartWrapper({
              closed the legend renders only a small reopen button and the
              chart reclaims the width. Height belongs to the legend itself:
              short lists should not reserve an empty chart-height column. */
-          <div className="w-full lg:w-auto lg:shrink-0 lg:self-start relative mt-3 lg:mt-0 lg:has-[.sidebar-legend]:w-fit lg:has-[.sidebar-legend]:min-w-48 lg:has-[.sidebar-legend]:max-w-96">
+          <div
+            data-slot="chart-legend-wrapper"
+            className="w-full lg:w-auto lg:shrink-0 lg:self-start relative mt-3 lg:mt-0 lg:has-[.sidebar-legend]:w-fit lg:has-[.sidebar-legend]:min-w-48 lg:has-[.sidebar-legend]:max-w-96"
+          >
             {legendElement}
           </div>
         )}

--- a/packages/app/src/hooks/useChartExport.test.ts
+++ b/packages/app/src/hooks/useChartExport.test.ts
@@ -24,15 +24,19 @@ describe('useChartExport failure messages', () => {
   let exportContainer: HTMLDivElement;
   let current: ReturnType<typeof useChartExport>;
   let originalFonts: PropertyDescriptor | undefined;
+  let hideLegend: boolean | undefined;
+  const setIsLegendExpanded = vi.fn();
 
   function HookProbe() {
-    current = useChartExport({ chartId: 'inference-chart' });
+    current = useChartExport({ chartId: 'inference-chart', hideLegend, setIsLegendExpanded });
     return null;
   }
 
   beforeEach(() => {
     exportMocks.pathname = '/inference';
     exportMocks.toPng.mockReset();
+    hideLegend = undefined;
+    setIsLegendExpanded.mockReset();
     originalFonts = Object.getOwnPropertyDescriptor(document, 'fonts');
     Object.defineProperty(document, 'fonts', {
       configurable: true,
@@ -84,6 +88,67 @@ describe('useChartExport failure messages', () => {
     expect(current.isExporting).toBe(false);
     expect(exportContainer.childElementCount).toBe(0);
     expect(chart.textContent).toBe('DeepSeek R1');
+  });
+
+  it.each([true, false])(
+    'omits the legend column and keeps official/overlay labels when the sidebar is open=%s',
+    async (open) => {
+      chart.innerHTML = `
+        <div class="flex">
+          <div class="relative"><div class="relative">
+            <svg data-testid="d3-chart-svg">
+              <text class="line-label">B200</text>
+              <text class="line-label">Unofficial MI355X</text>
+            </svg>
+          </div></div>
+          <div data-slot="chart-legend-wrapper">
+            ${open ? '<div class="legend-container">Legend hardware</div>' : '<button data-testid="legend-open-button">Show legend</button>'}
+          </div>
+        </div>`;
+      const original = chart.innerHTML;
+      hideLegend = true;
+      act(() => root.render(createElement(HookProbe)));
+      const captured = new Error('stop after capture assertions');
+      let snapshot: HTMLElement;
+      exportMocks.toPng.mockImplementationOnce((element: HTMLElement) => {
+        snapshot = element.cloneNode(true) as HTMLElement;
+        throw captured;
+      });
+      vi.spyOn(window, 'alert').mockImplementation(() => {});
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      await act(() => current.exportToImage());
+      expect(exportMocks.toPng).toHaveBeenCalledOnce();
+      expect(snapshot!.querySelector('[data-slot="chart-legend-wrapper"]')).toBeNull();
+      expect(snapshot!.querySelector('.legend-container')).toBeNull();
+      expect(snapshot!.querySelector('[data-testid="legend-open-button"]')).toBeNull();
+      expect(
+        [...snapshot!.querySelectorAll('.line-label')].map((label) => label.textContent),
+      ).toEqual(['B200', 'Unofficial MI355X']);
+      expect(setIsLegendExpanded).not.toHaveBeenCalled();
+      expect(chart.innerHTML).toBe(original);
+      expect(exportContainer.childElementCount).toBe(0);
+      expect(current.isExporting).toBe(false);
+    },
+  );
+
+  it('includes the legend again after line labels are toggled off', async () => {
+    chart.innerHTML =
+      '<div data-slot="chart-legend-wrapper"><div class="legend-container">B200</div></div>';
+    hideLegend = true;
+    act(() => root.render(createElement(HookProbe)));
+    hideLegend = false;
+    act(() => root.render(createElement(HookProbe)));
+    let snapshot: HTMLElement;
+    exportMocks.toPng.mockImplementationOnce((element: HTMLElement) => {
+      snapshot = element.cloneNode(true) as HTMLElement;
+      throw new Error('stop after capture assertions');
+    });
+    vi.spyOn(window, 'alert').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    await act(() => current.exportToImage());
+    expect(exportMocks.toPng).toHaveBeenCalledOnce();
+    expect(snapshot!.querySelector('.legend-container')?.textContent).toBe('B200');
+    expect(chart.querySelector('.legend-container')?.textContent).toBe('B200');
   });
 });
 

--- a/packages/app/src/hooks/useChartExport.ts
+++ b/packages/app/src/hooks/useChartExport.ts
@@ -12,6 +12,8 @@ const STRINGS = {
 interface UseChartExportOptions {
   chartId: string;
   setIsLegendExpanded?: (expanded: boolean) => void;
+  /** Omit the legend from the PNG without changing the interactive chart. */
+  hideLegend?: boolean;
   /** Human-readable base name for exported files (e.g. "DeepSeek-R1_throughput_interactivity"). Falls back to chartId. */
   exportFileName?: string;
 }
@@ -271,6 +273,7 @@ async function addWatermark(chartDataUrl: string, bgColor: string): Promise<stri
 export function useChartExport({
   chartId,
   setIsLegendExpanded,
+  hideLegend = false,
   exportFileName,
 }: UseChartExportOptions) {
   const locale = useLocale();
@@ -284,7 +287,7 @@ export function useChartExport({
     // .legend-container), so temporarily open it for the clone and restore
     // the closed state right after.
     let wasClosed = false;
-    if (setIsLegendExpanded) {
+    if (setIsLegendExpanded && !hideLegend) {
       const el = document.querySelector(`#${chartId}`);
       wasClosed = Boolean(el?.querySelector('[data-testid="legend-open-button"]'));
       if (wasClosed) {
@@ -307,6 +310,15 @@ export function useChartExport({
       // Remove duplicate export container from the clone to avoid DOM id conflicts
       const nestedExport = clone.querySelector(`[id="${chartId}-export"]`);
       if (nestedExport) nestedExport.remove();
+      if (hideLegend) {
+        // Remove the entire column, including its spacing and closed-state
+        // reopen button. Labels already identify the series in the plot.
+        for (const legend of clone.querySelectorAll(
+          '[data-slot="chart-legend-wrapper"], .legend-container',
+        )) {
+          legend.remove();
+        }
+      }
 
       // Bake computed text colors on the figcaption — html-to-image can't resolve
       // CSS custom properties (e.g. text-muted-foreground → var(--muted-foreground)).
@@ -527,7 +539,7 @@ export function useChartExport({
       const exportElement = document.querySelector<HTMLElement>(`#${chartId}-export`);
       if (exportElement) exportElement.innerHTML = '';
     }
-  }, [chartId, setIsLegendExpanded, t]);
+  }, [chartId, setIsLegendExpanded, hideLegend, exportFileName, t]);
 
   return { isExporting, exportToImage };
 }

--- a/packages/app/src/lib/d3-chart/typography.ts
+++ b/packages/app/src/lib/d3-chart/typography.ts
@@ -24,7 +24,7 @@ export const CHART_TYPE = {
   /** Small labels attached to marks (points, radar vertices, rulers). */
   dataLabel: 10,
   /** Series-identifying line labels, shared by interactive charts and PNGs. */
-  lineLabel: 16,
+  lineLabel: 13,
   /** Smallest legible size, for dense diagram labels. */
   micro: 9,
   /** Unofficial-results watermark pattern text. */

--- a/packages/app/src/lib/d3-chart/typography.ts
+++ b/packages/app/src/lib/d3-chart/typography.ts
@@ -23,6 +23,8 @@ export const CHART_TYPE = {
   annotationSub: 10,
   /** Small labels attached to marks (points, radar vertices, rulers). */
   dataLabel: 10,
+  /** Series-identifying line labels, shared by interactive charts and PNGs. */
+  lineLabel: 16,
   /** Smallest legible size, for dense diagram labels. */
   micro: 9,
   /** Unofficial-results watermark pattern text. */


### PR DESCRIPTION
## Summary

PNG exports omit the legend when Line Labels is enabled. The interactive legend stays available, and its open/closed state is unchanged by export.

Line-label text is now 13px (previously 10px) in both the interactive chart and PNG exports. A dedicated shared typography token controls the size, and the anchor collision spacing grows with it. Regression coverage checks the rendered font size, measured pill dimensions, plot-edge clamping, and zoom updates.

- Pass the current Line Labels state from `ChartDisplay` through `ChartButtons` to the shared export hook. This covers single-date ScatterGraph and comparison GPUGraph.
- Remove the entire legend column from the export clone, including the closed-state reopen button and column spacing. Do not reopen a closed legend when it will be omitted.
- Keep existing legend export behavior when Line Labels is disabled and for other callers that do not opt in.
- Keep official and unofficial line-label nodes in the captured chart; the clone filtering is independent of the data source.

## Verification

- `bun run test:unit`: passed across workspaces for the export change, including 5,390 app tests (4 skipped). The subsequent label-size change was checked with the targeted label, ScatterGraph, and export suites (81 tests).
- `bun run typecheck`: passed.
- `bun run lint`: passed.
- Export hook regression suite: 10 tests passed. Covers open/closed sidebar omission, preservation of official/overlay label nodes and the live DOM, export cleanup, and toggling line labels back off.
- Actual browser PNG downloads using committed API fixtures: Line Labels on removes the legend; off includes it; on with a closed sidebar leaves the sidebar closed.
- PNG examples were shared in the requesting Slack thread. These use committed test fixtures, not current benchmark results.
- Local `bun run test:e2e`: not green. The resident-sequence overlay case failed and the sandbox time limit terminated the run before completion. The full browser suite should be checked in CI.

No new UI strings or routes. Shared behavior applies to English and Chinese pages. Unofficial overlay label preservation is covered by the export-clone regression fixture; a real unofficial-run browser check was not performed.

## 中文说明

启用 Line Labels 后，导出的 PNG 不再包含图例。页面上的交互式图例仍然可用，导出不会改变图例的展开或收起状态。

交互式图表和 PNG 中的曲线标签均从 10px 放大到 13px，使用共享的字体尺寸常量，并相应增大锚点避让间距。回归测试覆盖字体大小、标签背景尺寸、绘图区边界限制和缩放更新。字体调整后重新运行了标签、ScatterGraph 和导出相关测试。

- 将 `ChartDisplay` 中的 Line Labels 状态经 `ChartButtons` 传给共享导出 hook，同时覆盖单日期 ScatterGraph 和对比视图 GPUGraph。
- 从导出副本中移除整个图例列，包括收起状态下的展开按钮及列间距。无需导出图例时，不再临时展开图例。
- 关闭 Line Labels 时保留原有图例导出行为；未启用该选项的其他调用方不受影响。
- 保留图中的官方和非官方曲线标签，副本过滤逻辑不区分数据来源。

验证：所有工作区的单元测试通过，其中 app 有 5,390 项通过、4 项跳过；TypeScript 类型检查和 lint 通过。导出 hook 的 10 项测试通过，覆盖图例展开/收起、标签保留、页面状态不变、失败清理及关闭 Line Labels 后恢复图例。

已使用提交到仓库的 API 测试数据，在浏览器中实际下载 PNG，确认标签开/关和图例收起时的行为，并在原 Slack 线程分享图片。图片使用测试数据，不代表最新基准测试结果。

本地 smoke 测试未全部通过：resident-sequence 的非官方 overlay 用例失败，随后运行因沙箱时间限制被终止，完整浏览器测试仍需在 CI 中确认。未新增 UI 文案或路由，英文和中文页面共用此行为。非官方标签保留已由导出副本测试覆盖，但未进行真实非官方 run 的浏览器验证。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect chart PNG export and in-plot label layout only, with dedicated unit tests and no auth or data-path impact.
> 
> **Overview**
> When **Line Labels** is enabled on inference charts, PNG exports now **drop the sidebar legend column** (including the collapsed reopen control) because series names already appear on the curves. The live chart and legend behavior are unchanged; a closed legend is no longer force-expanded during export when it would be omitted anyway.
> 
> **Line label pills** move from hard-coded **10px** to a shared **`CHART_TYPE.lineLabel` (13px)** token so interactive charts and exports stay aligned. Anchor collision spacing scales with the larger pills, and clamp-time layout tries **extra vertical row offsets** when mirror positions still overlap in dense clusters.
> 
> Wiring runs **`showLineLabels` → `hideLegendOnExport` → `useChartExport({ hideLegend })`**, with a **`data-slot="chart-legend-wrapper"`** hook on the legend column for reliable clone removal. Regression tests cover export snapshots, 13px sizing, and placement edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69fbbf70826b5de95ec7f6ef4f658e4a94fde637. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->