### PR TITLE
fix(chart): clear perf rulers when the x- or y-axis metric changes / 切换 x 轴或 y 轴指标时清除性能标尺

### DIFF
--- a/packages/app/cypress/component/scatter-graph.cy.tsx
+++ b/packages/app/cypress/component/scatter-graph.cy.tsx
@@ -1425,6 +1425,119 @@ describe('ScatterGraph', () => {
     cy.get('#test-scatter-dismiss-preview svg .unofficial-overlay-pt').should('not.exist');
     cy.get('#test-scatter-dismiss-preview svg .overlay-roofline-path').should('not.exist');
   });
+
+  it('clears perf rulers when the y-axis or x-axis metric changes', () => {
+    const chartId = 'test-scatter-perf-ruler-axis-reset';
+    // Distinct `conc` per point keeps the D3 join keys unique, as they are
+    // for real runs; the metric-change update matches marks by that key.
+    const officialData = ['b200_sglang', 'h100_vllm'].flatMap((hwKey, hwIndex) =>
+      [8, 16, 32].map((x, index) =>
+        createMockInferenceData({
+          hwKey,
+          x,
+          y: 320 - hwIndex * 120 - index * 40,
+          conc: x,
+          precision: Precision.FP4,
+        }),
+      ),
+    );
+    const baseInference = createMockInferenceContextValues();
+
+    function AxisMetricHarness() {
+      const [yMetric, setYMetric] = useState('y_tpPerGpu');
+      const [xField, setXField] = useState('p90_e2el');
+      const chartDefinition = createMockChartDefinition({
+        chartType: 'interactivity',
+        x_scale_field: xField,
+        y_tpPerGpu_roofline: 'upper_left',
+        y_totalTokensPerDollarTco_roofline: 'upper_left',
+      });
+      const inference = {
+        ...baseInference,
+        hardwareConfig: hwConfig,
+        activeHwTypes: new Set(['b200_sglang', 'h100_vllm']),
+        hwTypesWithData: new Set(['b200_sglang', 'h100_vllm']),
+        selectedModel: Model.DeepSeek_V4_Pro,
+        selectedSequence: Sequence.AgenticTraces,
+        selectedPrecisions: [Precision.FP4],
+        selectedYAxisMetric: yMetric,
+      };
+
+      return (
+        <InferenceContextsProvider
+          data={inference}
+          filters={inference}
+          display={inference}
+          actions={inference}
+        >
+          <button
+            data-testid="change-y-metric"
+            onClick={() => setYMetric('y_totalTokensPerDollarTco')}
+          >
+            Change y metric
+          </button>
+          <button data-testid="change-x-metric" onClick={() => setXField('p90_ttft')}>
+            Change x metric
+          </button>
+          <div style={{ width: 800, height: 600 }}>
+            <ScatterGraph
+              chartId={chartId}
+              modelLabel={Model.DeepSeek_V4_Pro}
+              data={officialData}
+              xLabel="P90 End-to-end Latency (s)"
+              yLabel="Throughput / Chip (tok/s)"
+              chartDefinition={chartDefinition}
+            />
+          </div>
+        </InferenceContextsProvider>
+      );
+    }
+
+    mountWithProviders(<AxisMetricHarness />, { unofficial: {} });
+
+    // Ruler mode exposes one widened hit stroke per visible roofline; clicking
+    // two of them completes a measurement.
+    const placeRuler = () => {
+      cy.get(`#${chartId} svg .perf-ruler-hit`).should('have.length', 2);
+      cy.get(`#${chartId} svg .perf-ruler-hit`).eq(0).click({ force: true });
+      cy.get(`#${chartId} svg .perf-ruler-hit`).eq(1).click({ force: true });
+      cy.get(`#${chartId} svg .perf-ruler`).should('have.length', 1);
+    };
+
+    // Clearing the rulers also drops the "clear rulers" legend entry, which
+    // narrows the sidebar and rebuilds the chart while the metric-change
+    // tween is still running. Both three-point curves must still be drawn
+    // as real curves afterwards (a stale tween used to collapse them onto a
+    // single coordinate).
+    const expectCurvesIntact = () => {
+      cy.get(`#${chartId} svg .roofline-path`)
+        .should('have.length', 2)
+        .each(($path) => {
+          expect($path.attr('d')).to.match(/C/);
+        });
+    };
+
+    expectCurvesIntact();
+    expandLegendAdvanced();
+    cy.get('#scatter-perf-ruler').click({ force: true });
+    placeRuler();
+
+    // Switching the y-axis metric redraws the curves in new units: the ruler
+    // must not survive. Ruler mode itself stays on so the user can measure
+    // again without re-enabling it.
+    cy.get('[data-testid="change-y-metric"]').click();
+    cy.get(`#${chartId} svg .perf-ruler`).should('not.exist');
+    cy.get('#scatter-perf-ruler').should('have.attr', 'aria-checked', 'true');
+    expectCurvesIntact();
+    placeRuler();
+
+    // Same for the x-axis metric (the resolved `x_scale_field`).
+    cy.get('[data-testid="change-x-metric"]').click();
+    cy.get(`#${chartId} svg .perf-ruler`).should('not.exist');
+    cy.get('#scatter-perf-ruler').should('have.attr', 'aria-checked', 'true');
+    expectCurvesIntact();
+    placeRuler();
+  });
 });
 
 describe('ChartDisplay responsive status notes', () => {

--- a/packages/app/src/components/inference/ui/GPUGraph.tsx
+++ b/packages/app/src/components/inference/ui/GPUGraph.tsx
@@ -24,6 +24,7 @@ import { generateGpuDateColors, generateHighContrastGpuDateColors } from '@/lib/
 import { useLocale } from '@/lib/use-locale';
 import { formatNumber, getDisplayLabel, updateRepoUrl } from '@/lib/utils';
 import { useThemeColors } from '@/hooks/useThemeColors';
+import { perfRulerAxisMetricKey, usePerfRulerAxisReset } from '@/hooks/usePerfRulerAxisReset';
 import { useTraceAvailability } from '@/hooks/api/use-trace-availability';
 import { useLogAvailability } from '@/hooks/api/use-log-availability';
 import { D3Chart } from '@/lib/d3-chart/D3Chart';
@@ -757,13 +758,22 @@ const GPUGraph = React.memo(
     // Same curve-to-curve ISO-X semantics as ScatterGraph, applied to the
     // date/chip comparison view: each measurement is two rendered roofline
     // paths (class tokens `roofline-<date>_<hwKey>_<precision>`) plus an
-    // iso-x stored in DATA space so it survives zoom and metric changes.
+    // iso-x stored in DATA space so it survives zoom (axis-metric changes
+    // clear rulers; see usePerfRulerAxisReset).
     // Any two curves may be paired — two dates of the same chip config, two
     // chip configs on the same date, or a mix — which is the point of this
     // view: quantify the multiple between comparison series at a glance.
     const [savedPerfRulerMode, setPerfRulerMode] = useState(false);
     const perfRulerMode = savedPerfRulerMode && !powerEnvelopeMode;
     const [perfRulerState, setPerfRulerState] = useState<PerfRulerState>(EMPTY_PERF_RULER_STATE);
+    // Changing the x- or y-axis metric clears every ruler: the curves are
+    // redrawn in different units, so a ruler that persisted would measure a
+    // ratio the user never placed. Runs before the draw pass so no stale
+    // ruler ever paints over the new curves.
+    usePerfRulerAxisReset(
+      perfRulerAxisMetricKey(chartDefinition.x_scale_field, selectedYAxisMetric),
+      setPerfRulerState,
+    );
     // Draw passes read mode/state through refs so toggling off clears the
     // rulers in the same pre-paint layout pass (no lingering frame).
     const perfRulerModeRef = useRef(perfRulerMode);

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -83,6 +83,7 @@ import {
   xMarkerPath,
 } from '@/lib/d3-chart/overlay-x-marker';
 import { useStableValue } from '@/hooks/useStableValue';
+import { perfRulerAxisMetricKey, usePerfRulerAxisReset } from '@/hooks/usePerfRulerAxisReset';
 import {
   overlayRooflineDasharray,
   overlayRunColor,
@@ -1507,13 +1508,23 @@ const ScatterGraph = React.memo(
     // Curve-to-curve ISO-X semantics: each measurement is two CURVES
     // (rendered roofline path class tokens) plus a freely chosen iso-x
     // stored in DATA space (xScale.invert of the click), so measurements
-    // survive zoom and metric changes. BOTH ruler ends are interpolated on
+    // survive zoom (axis-metric changes clear them; see
+    // usePerfRulerAxisReset). BOTH ruler ends are interpolated on
     // the curves' rendered paths at the iso-x — neither end needs to be a
     // data point. Multiple rulers accumulate (capped in the pure module);
     // completing one immediately allows starting the next.
     const [preferPerfRulerMode, setPerfRulerMode] = useState(false);
     const perfRulerMode = preferPerfRulerMode && !showPowerEnvelope;
     const [perfRulerState, setPerfRulerState] = useState<PerfRulerState>(EMPTY_PERF_RULER_STATE);
+    // Changing the x- or y-axis metric (including the x percentile, which
+    // `x_scale_field` encodes) clears every ruler: the curves are redrawn
+    // in different units, so a ruler that persisted would measure a ratio
+    // the user never placed. Runs before the draw pass so no stale ruler
+    // ever paints over the new curves.
+    usePerfRulerAxisReset(
+      perfRulerAxisMetricKey(chartDefinition.x_scale_field, selectedYAxisMetric),
+      setPerfRulerState,
+    );
     // Draw passes read mode/state through refs so toggling off clears the
     // rulers in the same pre-paint layout pass — lines/labels must never
     // linger a frame after the switch flips (Bugbot report on PR #853).

--- a/packages/app/src/hooks/usePerfRulerAxisReset.test.tsx
+++ b/packages/app/src/hooks/usePerfRulerAxisReset.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+import { act, useState } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { describe, expect, it } from 'vitest';
+
+import { EMPTY_PERF_RULER_STATE, type PerfRulerState } from '@/lib/d3-chart/layers/perf-ruler';
+
+import { perfRulerAxisMetricKey, usePerfRulerAxisReset } from './usePerfRulerAxisReset';
+
+const PLACED: PerfRulerState = {
+  rulers: [{ id: 1, curveA: 'roofline-a', curveB: 'roofline-b', isoX: 42 }],
+  draft: { curve: 'roofline-c', isoX: 7 },
+  nextId: 2,
+};
+
+interface Snapshot {
+  state: PerfRulerState;
+  renders: number;
+}
+
+interface Harness {
+  snapshot: Snapshot;
+  rerender: (axisMetricKey: string) => void;
+  place: () => void;
+  unmount: () => void;
+}
+
+/**
+ * Mounts a component that owns real perf-ruler state and runs the hook, so
+ * the test observes exactly what a chart component would: the state the
+ * draw pass reads after the axis key changes.
+ */
+function mountHarness(initialKey: string): Harness {
+  const snapshot: Snapshot = { state: EMPTY_PERF_RULER_STATE, renders: 0 };
+  let axisMetricKey = initialKey;
+  let setState: ((next: PerfRulerState) => void) | null = null;
+
+  function TestComponent() {
+    const [perfRulerState, setPerfRulerState] = useState<PerfRulerState>(EMPTY_PERF_RULER_STATE);
+    setState = setPerfRulerState;
+    usePerfRulerAxisReset(axisMetricKey, setPerfRulerState);
+    snapshot.state = perfRulerState;
+    snapshot.renders += 1;
+    return null;
+  }
+
+  const container = document.createElement('div');
+  document.body.append(container);
+  const root: Root = createRoot(container);
+  const render = () => {
+    act(() => {
+      root.render(<TestComponent />);
+    });
+  };
+  render();
+
+  return {
+    snapshot,
+    rerender: (next) => {
+      axisMetricKey = next;
+      render();
+    },
+    place: () => {
+      act(() => {
+        setState?.(PLACED);
+      });
+    },
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+describe('usePerfRulerAxisReset', () => {
+  it('leaves rulers alone while the axis metrics are unchanged', () => {
+    const key = perfRulerAxisMetricKey('p90_e2el', 'y_totalTokensPerDollarTco');
+    const h = mountHarness(key);
+    h.place();
+    expect(h.snapshot.state).toBe(PLACED);
+
+    // Unrelated re-renders (legend toggles, zoom, date changes) pass the
+    // same key and must not disturb placed rulers or the draft.
+    h.rerender(key);
+    h.rerender(key);
+    expect(h.snapshot.state).toBe(PLACED);
+    h.unmount();
+  });
+
+  it('clears rulers and the draft when the y-axis metric changes', () => {
+    const h = mountHarness(perfRulerAxisMetricKey('p90_e2el', 'y_totalTokensPerDollarTco'));
+    h.place();
+    h.rerender(perfRulerAxisMetricKey('p90_e2el', 'y_tpPerGpu'));
+    expect(h.snapshot.state.rulers).toEqual([]);
+    expect(h.snapshot.state.draft).toBeNull();
+    // Ids keep counting so a ruler placed after the switch never reuses a
+    // key the D3 join may still hold.
+    expect(h.snapshot.state.nextId).toBe(PLACED.nextId);
+    h.unmount();
+  });
+
+  it('clears rulers when the x-axis metric or percentile changes', () => {
+    const h = mountHarness(perfRulerAxisMetricKey('p90_e2el', 'y_totalTokensPerDollarTco'));
+    h.place();
+    h.rerender(perfRulerAxisMetricKey('p90_ttft', 'y_totalTokensPerDollarTco'));
+    expect(h.snapshot.state.rulers).toEqual([]);
+    expect(h.snapshot.state.draft).toBeNull();
+
+    h.place();
+    h.rerender(perfRulerAxisMetricKey('median_ttft', 'y_totalTokensPerDollarTco'));
+    expect(h.snapshot.state.rulers).toEqual([]);
+    expect(h.snapshot.state.draft).toBeNull();
+    h.unmount();
+  });
+
+  it('keeps the empty state referentially stable across an axis change', () => {
+    const h = mountHarness(perfRulerAxisMetricKey('p90_e2el', 'y_totalTokensPerDollarTco'));
+    const before = h.snapshot.state;
+    h.rerender(perfRulerAxisMetricKey('p90_e2el', 'y_tpPerGpu'));
+    expect(h.snapshot.state).toBe(before);
+    h.unmount();
+  });
+
+  it('distinguishes axis pairs that would collide under naive concatenation', () => {
+    expect(perfRulerAxisMetricKey('ab', 'c')).not.toBe(perfRulerAxisMetricKey('a', 'bc'));
+  });
+});

--- a/packages/app/src/hooks/usePerfRulerAxisReset.ts
+++ b/packages/app/src/hooks/usePerfRulerAxisReset.ts
@@ -1,0 +1,41 @@
+import { useState, type Dispatch, type SetStateAction } from 'react';
+
+import { clearPerfRulers, type PerfRulerState } from '@/lib/d3-chart/layers/perf-ruler';
+
+/**
+ * Clear every perf ruler (and any in-progress draft) when the chart's axis
+ * metrics change.
+ *
+ * A ruler measures the multiple between two curves at one iso-x, in the
+ * units of the axes it was placed on. Swapping the y-axis metric (e.g. from
+ * total tokens per dollar to throughput per GPU) or the x-axis metric (e.g.
+ * from P90 end-to-end latency to TTFT, or between percentiles) redraws
+ * every curve with unrelated geometry, so a surviving ruler would report a
+ * ratio the user never asked for at an x that now means something else.
+ * Rulers do survive zoom, legend toggles, and date changes — those keep
+ * the axis units intact.
+ *
+ * `axisMetricKey` is the caller's identity for the current axis pair. The
+ * reset runs as render-time derived state (the "adjusting state when a prop
+ * changes" pattern) rather than in an effect, so the D3 draw pass that
+ * follows the metric change already sees the cleared state: no frame ever
+ * paints stale rulers over the new curves. The initial key never triggers
+ * a reset, so rulers restored on mount are left alone.
+ */
+export function usePerfRulerAxisReset(
+  axisMetricKey: string,
+  setPerfRulerState: Dispatch<SetStateAction<PerfRulerState>>,
+): void {
+  const [appliedAxisMetricKey, setAppliedAxisMetricKey] = useState(axisMetricKey);
+  if (appliedAxisMetricKey !== axisMetricKey) {
+    setAppliedAxisMetricKey(axisMetricKey);
+    // `clearPerfRulers` returns the same reference when nothing is placed,
+    // so an axis change with no rulers does not schedule a wasted update.
+    setPerfRulerState(clearPerfRulers);
+  }
+}
+
+/** Build the axis identity consumed by {@link usePerfRulerAxisReset}. */
+export function perfRulerAxisMetricKey(xAxisField: string, yAxisMetric: string): string {
+  return `${xAxisField}\u0000${yAxisMetric}`;
+}


### PR DESCRIPTION
## Summary

Perf rulers persisted across x-axis and y-axis metric changes. A ruler measures the multiple between two curves at one iso-x in the units of the axes it was placed on; after switching, for example, from "Total Tokens per $1 TCO" to "Throughput per GPU", or from P90 E2E latency to TTFT, the curves are redrawn with unrelated geometry and the surviving ruler reports a ratio the user never placed on the new chart.

## Fix

- New `usePerfRulerAxisReset(axisMetricKey, setPerfRulerState)` hook in `packages/app/src/hooks/usePerfRulerAxisReset.ts`, shared by `ScatterGraph` and `GPUGraph`.
- The key is `perfRulerAxisMetricKey(chartDefinition.x_scale_field, selectedYAxisMetric)`. `x_scale_field` already encodes the x metric and its percentile (`p90_e2el`, `p90_ttft`, `median_intvty`, ...), so percentile switches clear rulers too.
- The reset is render-time derived state (React's "adjusting state when a prop changes" pattern) rather than an effect, so the D3 draw pass after the metric change already sees the cleared state and no frame paints a stale ruler over the new curves.
- Ruler mode stays on; zoom, legend toggles, and date changes still preserve rulers. `clearPerfRulers` returns the same reference when nothing is placed, so metric changes with no rulers schedule no extra update.

## Tests

- `packages/app/src/hooks/usePerfRulerAxisReset.test.tsx`: no reset on mount, clears rulers and draft on key change, no-op when the key is stable or nothing is placed, x-only and y-only key changes both reset.
- `packages/app/cypress/component/scatter-graph.cy.tsx`: places a ruler, switches the y metric, asserts the ruler is gone and ruler mode is still on, places again; then the same for the x metric. Also asserts both rooflines survive as real curves after each switch.
- `bun run typecheck`, `bun run lint`, `bun run fmt`, `bun run check:typography`, and the full `scatter-graph.cy.tsx` spec (42 passing) are clean.

## 中文说明

切换 x 轴或 y 轴指标后，性能标尺仍然保留。标尺测量的是两条曲线在同一 iso-x 处的倍数，单位取决于放置时的坐标轴；切换指标（例如从每美元 TCO 总 token 数切到每 GPU 吞吐，或从 P90 端到端延迟切到 TTFT）后曲线几何完全不同，残留的标尺显示的倍数已无意义。

修复：新增 `usePerfRulerAxisReset` 钩子，`ScatterGraph` 与 `GPUGraph` 共用，以 `x_scale_field`（已包含 x 指标及百分位）和 `selectedYAxisMetric` 组合为键，在渲染期以派生状态方式清除所有标尺与草稿，保证 D3 绘制时不会出现旧标尺；标尺模式保持开启，缩放、图例切换和日期切换仍保留标尺。

测试：钩子单元测试；ScatterGraph 组件测试覆盖切换 y 轴与 x 轴指标后标尺被清除且可重新放置。typecheck、lint、fmt、typography 与完整 scatter-graph 组件测试均通过。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped chart UX fix with render-time state reset and unit/component tests; no auth, API, or data-path changes.
> 
> **Overview**
> **Perf rulers no longer stick around after you change x- or y-axis metrics**, which used to show misleading curve ratios in new units.
> 
> Adds shared **`usePerfRulerAxisReset`** with **`perfRulerAxisMetricKey`** (`x_scale_field` + `selectedYAxisMetric`, including percentile changes on x). **`ScatterGraph`** and **`GPUGraph`** call it during render so rulers clear before the next D3 draw—no stale overlay frame. **Ruler mode stays on**; zoom and other filters still keep rulers. Comments now say rulers survive zoom only, not axis changes.
> 
> **Tests:** Vitest for the hook; Cypress places rulers, switches y then x metrics, asserts rulers gone, mode still on, roofline curves intact, and rulers can be placed again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd571dbc93e0ad508e0e5f9ab8c2946d15821973. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->